### PR TITLE
Stats improvements

### DIFF
--- a/slash/shared/src/main/scala/ai/dragonfly/math/vector/package.scala
+++ b/slash/shared/src/main/scala/ai/dragonfly/math/vector/package.scala
@@ -275,12 +275,6 @@ package object vector {
         mag2
       }
 
-      inline def minElement = {
-        thisVector.asInstanceOf[NArray[Double]].min
-      }
-
-
-
       inline def norm: Double = Math.sqrt(normSquared)
 
       inline def magnitude: Double = norm

--- a/tests/shared/src/test/scala/Instantiate.scala
+++ b/tests/shared/src/test/scala/Instantiate.scala
@@ -26,6 +26,7 @@ class InstantiateTests extends munit.FunSuite:
     val v = Vec.fromTuple(1.0, 2.0, 3.0, 4.0, 5.0)
     val v2 = Vec[5](1.0, 2.0, 3.0, 4.0, 5.0)
     val v_fill = Vec.fill[5](1.0)
+    val v_tabulate = Vec.tabulate[5](i => i.toDouble)
 
     val v_zeros = Vec.zeros[5]
     val v_ones = Vec.ones[5]
@@ -36,8 +37,8 @@ class InstantiateTests extends munit.FunSuite:
 
     assertEquals(v2.dimension, v2.dimension )
     assertEquals(v2.dimension, v_fill.dimension )
+    assertEquals(v2.dimension, v_tabulate.dimension )
     assertEquals(v2.dimension, v_zeros.dimension )
-    assertEquals(v2.dimension, v_rand.dimension )
     assertEquals(v2.dimension, v_rand.dimension )
     assertEquals(v2.dimension, v_rand_max_min.dimension )
 

--- a/tests/shared/src/test/scala/SimpleStats.scala
+++ b/tests/shared/src/test/scala/SimpleStats.scala
@@ -30,9 +30,14 @@ class SimpleStatsTests extends munit.FunSuite:
       assertNotEquals(v, v2 )
    }
 
+    test("sum") {
+      val v = Vec[5](1.0,2,3,4,5.0)
+      assertEquals(v.sum , 15.0)
+    }
+
    test("sample mean") {
-    val v = Vec.fromTuple(2.0,4.0,4.0,4.0,5.0,5.0,7.0,9.0)
-    assertEquals(v.mean , 5.0)
+    val v = Vec[5](1.0,2,3,4,5.0)
+    assertEquals(v.mean , 3.0)
    }
 
    test("sample variance and std") {
@@ -82,4 +87,12 @@ class SimpleStatsTests extends munit.FunSuite:
     val v4 = Vec[10](2, 20.0, 28.0, 27.0, 50.0, 29.0, 7.0, 17.0, 6.0, 12.0)
     assertEqualsDouble(-0.1757575, v3.spearmansRankCorrelation(v4), 0.000001);
    }
+
+   test("min max") {
+      val v = Vec.fromTuple(1.0, 5.0, 3.0, 6.0, 1.0, 5.0)
+      assertEquals(v.minElement, 1.0)
+      //assertEquals(v.maxElement, 6.0)
+   }
+
+
 end SimpleStatsTests

--- a/tests/shared/src/test/scala/SimpleStats.scala
+++ b/tests/shared/src/test/scala/SimpleStats.scala
@@ -88,11 +88,4 @@ class SimpleStatsTests extends munit.FunSuite:
     assertEqualsDouble(-0.1757575, v3.spearmansRankCorrelation(v4), 0.000001);
    }
 
-   test("min max") {
-      val v = Vec.fromTuple(1.0, 5.0, 3.0, 6.0, 1.0, 5.0)
-      assertEquals(v.minElement, 1.0)
-      //assertEquals(v.maxElement, 6.0)
-   }
-
-
 end SimpleStatsTests


### PR DESCRIPTION
Here are a few improvements which  would have a positive performance impact on the spearman calc (I believe)

- I realised that "sum" called down to an inefficient looking fold method, so I wrote that one by hand
- Element ranks now appends its results to a mutable array instead of constantly recreating immutable ones. I hope the impact here will be quite large
- spearman now takes a single pass through all it's arrays instead of calculating them seperately. - as hinted on discord. 

I've left the other methods as is for the time being, as it sounds like you may wish to accomplish them other ways. 

There's no pressure to merge! 