### PR TITLE
Fix Theta typo

### DIFF
--- a/slash/shared/src/main/scala/slash/vector/package.scala
+++ b/slash/shared/src/main/scala/slash/vector/package.scala
@@ -157,9 +157,9 @@ package object vector {
      * Vec[2] extension methods:
      */
     extension[N <: Int] (thisVector: Vec[N])(using ValueOf[N], N == 2 =:= true) {
-      inline def rotate(cosTheta: Double, sinTheata: Double): Unit = {
-        val x1 = thisVector(0) * cosTheta - thisVector(1) * sinTheata
-        thisVector(1) = thisVector(0) * sinTheata + thisVector(1) * cosTheta
+      inline def rotate(cosTheta: Double, sinTheta: Double): Unit = {
+        val x1 = thisVector(0) * cosTheta - thisVector(1) * sinTheta
+        thisVector(1) = thisVector(0) * sinTheta + thisVector(1) * cosTheta
         thisVector(0) = x1
       }
       inline def rotate(radians: Double): Unit = rotate(Math.cos(radians), Math.sin(radians))


### PR DESCRIPTION
Fixes a small typo in `Vec[N]#rotate`.

I believe this should have been `Theta` instead of `Theata`.