### PR TITLE
add factory method to create matrix from tuple

### DIFF
--- a/tests/shared/src/test/scala/MatrixExtensionsTest.scala
+++ b/tests/shared/src/test/scala/MatrixExtensionsTest.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import slash.vector.*
+import slash.vector.Vec
 import slash.matrix.*
 import slash.matrix.Matrix.*
 
@@ -33,10 +33,55 @@ class MatrixExtensionsTest extends munit.FunSuite {
   }
 
   test("Matrix can be initialized from Tuple literal") {
-    import slash.matrix.*
-    val tup3x2 = ( (1, 2), (3, 4), (5, 6))
-    val m01: Matrix[3, 2] = Mat(tup3x2)
-    val m02               = Mat(tup3x2)
-    assert(m01.toString == m02.toString)
+    val tup3x2 = (((1, 2), (3, 4), (5, 6)))
+    val m01: Matrix[3, 2] = Matrix(tup3x2)
+    val m02 = Matrix(((1, 2), (3, 4), (5, 6)))
+    assert(m01 == m02)
+  }
+  test("Matrix equality for Tuples with mixed number types") {
+    // values selected to avoid roundoff errors
+    val m01: Matrix[2, 2] = Matrix(((1, 2L), (2.0, 4f))) // Int, Long, Double, Float
+    val m02: Matrix[2, 2] = Matrix(((1L, 2.0), (2f, 4))) // Long, Double, Float, Int
+    assert(m01 == m02)
+  }
+  test("Same values but unequal Dimensions should not equate") {
+    val mat3x2 = Matrix[3,2](1, 2, 3, 4, 5, 6)
+    val mat2x3 = Matrix[2,3](1, 2, 3, 4, 5, 6)
+    assert(mat3x2 != mat2x3)
+  }
+  test("Single or repeating Tuple parameters should be equivalent") {
+    val tup1 = (((1, 2), (3, 4), (5, 6))) // single Tuple[Tuple] arg
+    val tup2 =  ((1, 2), (3, 4), (5, 6))  // repeating Tuple args
+    val m01: Matrix[3, 2] = Matrix(tup1)
+    val m02: Matrix[3, 2] = Matrix(tup2)
+    assert(m01 == m02)
+  }
+  test("Matrix with NaN fields unequal even if NaNs are aligned") {
+    val m01: Matrix[1, 2] = Matrix(3, Double.NaN)
+    val m02: Matrix[1, 2] = Matrix(3, Double.NaN)
+    assert(m01 != m02)
+  }
+  test("Tuples with non-number fields throw IllegalArgumentException") {
+    val tup1 = (((1, 2), (3, 4), ("", false))) // last row is (NaN, NaN)
+    val compilerError = try {
+      val mat = Matrix(tup1)
+      printf("%s\n", mat)
+      false // fail if exception not thrown 
+    } catch {
+      case _ =>
+        true // as expected
+    }
+    assert(compilerError)
+  }
+  test("Tuples with jagged rows should throw IllegalArgumentException") {
+    val compilerError = try {
+      val mat = Matrix(((1, 2), (3, 4, 5))) // compiler error
+      printf("%s\n", mat)
+      false // fail if exception not thrown 
+    } catch {
+      case _ =>
+        true // as expected
+    } 
+    assert(compilerError)
   }
 }

--- a/tests/shared/src/test/scala/MatrixExtensionsTest.scala
+++ b/tests/shared/src/test/scala/MatrixExtensionsTest.scala
@@ -16,6 +16,7 @@
 
 import slash.vector.*
 import slash.matrix.*
+import slash.matrix.Matrix.*
 
 class MatrixExtensionsTest extends munit.FunSuite {
   test("Matrix[1, N] -> Vec[N] -> Matrix[1, N]") {
@@ -29,5 +30,13 @@ class MatrixExtensionsTest extends munit.FunSuite {
     val mVec: Vec[N] = m.asVector
     assertMatrixEquals[1, N](m, mVec.asRowMatrix)
 
+  }
+
+  test("Matrix can be initialized from Tuple literal") {
+    import slash.matrix.*
+    val tup3x2 = ( (1, 2), (3, 4), (5, 6))
+    val m01: Matrix[3, 2] = Mat(tup3x2)
+    val m02               = Mat(tup3x2)
+    assert(m01.toString == m02.toString)
   }
 }

--- a/tests/shared/src/test/scala/MatrixExtensionsTest.scala
+++ b/tests/shared/src/test/scala/MatrixExtensionsTest.scala
@@ -36,30 +36,30 @@ class MatrixExtensionsTest extends munit.FunSuite {
     val tup3x2 = (((1, 2), (3, 4), (5, 6)))
     val m01: Matrix[3, 2] = Matrix(tup3x2)
     val m02 = Matrix(((1, 2), (3, 4), (5, 6)))
-    assert(m01 == m02)
+    assert(m01.strictEquals(m02))
   }
   test("Matrix equality for Tuples with mixed number types") {
     // values selected to avoid roundoff errors
     val m01: Matrix[2, 2] = Matrix(((1, 2L), (2.0, 4f))) // Int, Long, Double, Float
     val m02: Matrix[2, 2] = Matrix(((1L, 2.0), (2f, 4))) // Long, Double, Float, Int
-    assert(m01 == m02)
+    assert(m01.strictEquals(m02))
   }
   test("Same values but unequal Dimensions should not equate") {
     val mat3x2 = Matrix[3,2](1, 2, 3, 4, 5, 6)
     val mat2x3 = Matrix[2,3](1, 2, 3, 4, 5, 6)
-    assert(mat3x2 != mat2x3)
+    assert(!mat3x2.strictEquals(mat2x3))
   }
   test("Single or repeating Tuple parameters should be equivalent") {
     val tup1 = (((1, 2), (3, 4), (5, 6))) // single Tuple[Tuple] arg
     val tup2 =  ((1, 2), (3, 4), (5, 6))  // repeating Tuple args
     val m01: Matrix[3, 2] = Matrix(tup1)
     val m02: Matrix[3, 2] = Matrix(tup2)
-    assert(m01 == m02)
+    assert(m01.strictEquals(m02))
   }
   test("Matrix with NaN fields unequal even if NaNs are aligned") {
     val m01: Matrix[1, 2] = Matrix(3, Double.NaN)
     val m02: Matrix[1, 2] = Matrix(3, Double.NaN)
-    assert(m01 != m02)
+    assert(!m01.strictEquals(m02))
   }
   test("Tuples with non-number fields throw IllegalArgumentException") {
     val tup1 = (((1, 2), (3, 4), ("", false))) // last row is (NaN, NaN)


### PR DESCRIPTION
The new factory method can be used to initialize a `Matrix` from a tuple literal, as in the example script.
Declaring Matrix dimensions at the call site is optional.
Note that the matrix contains type `Double`, but the tuple can contain any Number type:
```scala
  type Number = Double | Int | Long | Float | BigDecimal
```
```scala
#!/usr/bin/env -S scala-cli shebang

//> using dep ai.dragonfly::slash::0.3-42a6354-SNAPSHOT
import narr.NArray
import narr.NArray.*
//import slash.vector.*
import slash.matrix.*
import scala.compiletime.{constValue, summonInline}
import scala.compiletime.ops.int.*


// Usage example
val tup3x2 = (
  (1, 2),
  (3, 4),
  (5, 6)
)
val tup2x3 = (
  (1.1,1.2,1.3),
  (2.1, 2.2, 2.3)
)
val tup4x5 = (
  (1,2,1,2,1),
  (2,3,2,3,2),
  (3,4,3,4,3),
  (4,5,4,5,4),
)
val tup4x5alt = (
  (6,7,6,7,6),
  (7,8,7,8,7),
  (8,9,8,9,8),
  (9,5,9,5,9),
)
var m00: Matrix[4,5] = Mat(tup4x5)
printf("%s\n", m00)
m00 = Mat(tup4x5alt)
printf("%s\n", m00)

