### PR TITLE
Add support for creating a Matrix from repeated row tuples  #65

### DIFF
--- a/slash/shared/src/main/scala/slash/matrix/Matrix.scala
+++ b/slash/shared/src/main/scala/slash/matrix/Matrix.scala
@@ -266,7 +266,7 @@ object Matrix {
    *  `((a,b,c...),(d,e,f,...),...)`.
    *
    * Where:
-   *    sequence of tuples share the same arity
+   *    the sequence of tuples share the same arity
    *    tuple Numeric fields converted to type Double
    *    non-numeric fields, if present converted to `Double.NaN`
    * @param tup a tuple with M Number tuples of arity N
@@ -274,7 +274,10 @@ object Matrix {
    */
   transparent inline def apply[T <: Tuple](inline t: T *) = {
     val rows: Int = t.size
-    val cols: Int = t.take(1).size
+    val cols: Int = t.toList match {
+      case Nil => 0
+      case head :: _ => head.productIterator.toArray.size
+    }
     val itr1:Iterator[Any] = t.iterator
     val matsize1: Int = rows * cols
     val v:NArray[Double] = new NArray[Double](matsize1)
@@ -293,7 +296,7 @@ object Matrix {
         i += 1
         j += 1
       }
-      require(j == cols)
+      require(j == cols, s"i[$i]: j[$j] != cols[$cols]")
     }
     inline (rows, cols) match {
     case (r, c) =>

--- a/slash/shared/src/main/scala/slash/matrix/Matrix.scala
+++ b/slash/shared/src/main/scala/slash/matrix/Matrix.scala
@@ -234,7 +234,7 @@ object Matrix {
    */
   transparent inline def apply[T <: Tuple](inline t: T) = {
     val itr1:Iterator[Any] = t.productIterator
-    val matsize1: Int = valueOf[MatrixSize[T]]
+    val matsize1: Int = valueOf[TupleMatsize[T]]
     val v:NArray[Double] = new NArray[Double](matsize1)
     var i:Int = 0
     var columnCount = 0
@@ -262,6 +262,44 @@ object Matrix {
       new Matrix[r.type, c.type](v)
     }
   }
+  /** Construct a Matrix from a sequence of Tuple literals, with optional dimensions at call site.
+   *  `((a,b,c...),(d,e,f,...),...)`.
+   *
+   * Where:
+   *    sequence of tuples share the same arity
+   *    tuple Numeric fields converted to type Double
+   *    non-numeric fields, if present converted to `Double.NaN`
+   * @param tup a tuple with M Number tuples of arity N
+   * @return an M x N matrix consisting of values.
+   */
+  transparent inline def apply[T <: Tuple](inline t: T *) = {
+    val rows: Int = t.size
+    val cols: Int = t.take(1).size
+    val itr1:Iterator[Any] = t.iterator
+    val matsize1: Int = rows * cols
+    val v:NArray[Double] = new NArray[Double](matsize1)
+    var i:Int = 0
+    while (itr1.hasNext) {
+      val inner = itr1.next().asInstanceOf[Tuple]
+      val itr2:Iterator[Any] = inner.productIterator
+      var j:Int = 0
+      while (itr2.hasNext) {
+        itr2.next match {
+        case n: Number =>
+          v(i) = toDouble(n)
+        case x =>
+          throw new IllegalArgumentException(s"non-numeric Tuple field [$x]")
+        }
+        i += 1
+        j += 1
+      }
+      require(j == cols)
+    }
+    inline (rows, cols) match {
+    case (r, c) =>
+      new Matrix[r.type, c.type](v)
+    }
+  }
 
   type Number = Int | Float | Double | Long
 
@@ -283,8 +321,7 @@ object Matrix {
     case 0 => 0
     case S[aMinus1] => B + Product[aMinus1, B]
 
-  type MatrixSize[T <: Tuple] = Product[RowSize[T], ColSize[T]]
-
+  type TupleMatsize[T <: Tuple] = Product[RowSize[T], ColSize[T]]
 
   inline def dims[T <: Tuple](inline tup: T): (Int, Int) = {
     (constValue[RowSize[T]], constValue[ColSize[T]])

--- a/tests/shared/src/test/scala/MatrixExtensionsTest.scala
+++ b/tests/shared/src/test/scala/MatrixExtensionsTest.scala
@@ -85,7 +85,7 @@ class MatrixExtensionsTest extends munit.FunSuite {
     assert(compilerError)
   }
   test("Can create a Matrix from a Seq of row Tuple arguments") {
-    val mat = Matrix(((1, 2), (3, 4), (5.0, 6.0)))
+    val mat = Matrix((1, 2), (3, 4), (5, 6))
     assert(mat.rows == 3 && mat.columns == 2)
   }
   test("Seq[Tuple] Matrix with jagged rows should throw IllegalArgumentException") {
@@ -94,7 +94,7 @@ class MatrixExtensionsTest extends munit.FunSuite {
       printf("%s\n", mat)
       false // fail if exception not thrown 
     } catch {
-      case _ =>
+      case t =>
         true // as expected
     } 
     assert(compilerError)

--- a/tests/shared/src/test/scala/MatrixExtensionsTest.scala
+++ b/tests/shared/src/test/scala/MatrixExtensionsTest.scala
@@ -84,4 +84,19 @@ class MatrixExtensionsTest extends munit.FunSuite {
     } 
     assert(compilerError)
   }
+  test("Can create a Matrix from a Seq of row Tuple arguments") {
+    val mat = Matrix(((1, 2), (3, 4), (5.0, 6.0)))
+    assert(mat.rows == 3 && mat.columns == 2)
+  }
+  test("Seq[Tuple] Matrix with jagged rows should throw IllegalArgumentException") {
+    val compilerError = try {
+      val mat = Matrix((1, 2), (3, 4, 5)) // compiler error
+      printf("%s\n", mat)
+      false // fail if exception not thrown 
+    } catch {
+      case _ =>
+        true // as expected
+    } 
+    assert(compilerError)
+  }
 }


### PR DESCRIPTION
This implements the ability to do this:
```scala
val x = Matrix((1,2), (3.0, 4.1)) // repeated Tuple2 args
```
Currently, it's only possible to do it this way:
```scala
val x = Matrix(((1,2), (3.0, 4.1))) // single Tuple2[Tuple3[Number]] arg
```
Because the dimensions must be counted in the constructor, there is a performance penalty relative to creating a Matrix from a Tuple of Tuples.
