### PR TITLE
add left multiply for Vec and Mat plus tests; fix for #69

### DIFF
--- a/slash/shared/src/main/scala/slash/matrix/Mat.scala
+++ b/slash/shared/src/main/scala/slash/matrix/Mat.scala
@@ -345,6 +345,10 @@ object Mat {
     }
   }
 
+  // support left multiply by scalar
+  extension (d: Double) {
+    def *[M <: Int, N <: Int](m: Mat[M,N]): Mat[M,N] = m * d // same as right multiply
+  }
 }
 
 class Mat[M <: Int, N <: Int](val values: NArray[Double])(using ValueOf[M], ValueOf[N]) {

--- a/slash/shared/src/main/scala/slash/vector/package.scala
+++ b/slash/shared/src/main/scala/slash/vector/package.scala
@@ -549,6 +549,9 @@ package object vector {
       def tsv(sb: StringBuilder = new StringBuilder()): String = render(VecFormat.TSV, sb).toString
     }
 
+    extension (d: Double) {
+      def *[N <: Int](v: Vec[N]):Vec[N] = v * d
+    }
   }
 
   export Vec.*

--- a/tests/shared/src/test/scala/MatExtensionsTest.scala
+++ b/tests/shared/src/test/scala/MatExtensionsTest.scala
@@ -99,4 +99,20 @@ class MatExtensionsTest extends munit.FunSuite {
     } 
     assert(compilerError)
   }
+
+  test("scalar multiplication") {
+    val m1 = Mat[1,3](1.5, 2.5, 3.5)
+    val expected = Mat[1,3](3.0, 5.0, 7.0)
+    val result = m1 * 2.0
+    assert(result.strictEquals(expected))
+  }
+
+  test("scalar left multiplication") {
+    val m1 = Mat[1,3](1.5, 2.5, 3.5)
+    val expected = Mat[1,3](3.0, 5.0, 7.0)
+    val result = 2.0 * m1
+    assert(result.strictEquals(expected))
+  }
+
+
 }

--- a/tests/shared/src/test/scala/SimpleVecOpsTest.scala
+++ b/tests/shared/src/test/scala/SimpleVecOpsTest.scala
@@ -51,6 +51,11 @@ class SimpleVecOpsTest extends munit.FunSuite {
     val vResult = Vec[3](3.0, 5.0, 7.0)
     assertVecEquals(v1 * 2.0, vResult)
   }
+  test("scalar left multiplication") {
+    val v1 = Vec[3](1.5, 2.5, 3.5)
+    val vResult = Vec[3](3.0, 5.0, 7.0)
+    assertVecEquals(2.0 * v1, vResult)
+  }
 
   test("scalar division") {
     val v1 = Vec[3](1.5, 2.5, 3.5)


### PR DESCRIPTION
This makes is possible to both left and right multiply by a scalar, for both Mat and Vec.
With tests to verify.
implements #69