### PR TITLE
dimensionless factory methods renamed

### DIFF
--- a/slash/shared/src/main/scala/slash/matrix/package.scala
+++ b/slash/shared/src/main/scala/slash/matrix/package.scala
@@ -128,4 +128,14 @@ package object matrix {
     inline def copyAsVector[MN <: Int](using MN == (M * N) =:= true): Vec[MN] = narr.copy[Double](m.values).asInstanceOf[Vec[MN]]
   }
 
+  /*
+   * convert a Mat with non-literal dimensions to canonical form.
+   */
+  extension(m: Mat[?,?]) {
+    def cast[M <: Int, N <: Int](using ValueOf[M], ValueOf[N]): Mat[M,N] = {
+      dimensionCheck(m.values.size, valueOf[M] * valueOf[N])
+      Mat[M,N](m.values)
+    }
+  }
+
 }


### PR DESCRIPTION
Addresses comment about unsupported cases in #65.

It was necessary to rename dimensionless factory methods from `def apply` to `def mat`.
In other words, when dimensions are declared, the factory name is `def apply[M <: Int, N <: Int]` as before,
and otherwise it's `def mat(...)`.

The name collisions are a side-effect of supporting varargs of tuples, although it might have been inevitable anyway.  Any method that takes a single varargs sequence has the same signature after erasure, even if one has varargs `Double *` and the other has `Tuple *`.

Here's an example of the new method names,  from `MatExtensionsTest`:
```
  test("Mat from Tuple literals match whether dimensions provided") {
    val m01: Mat[3, 2] = Mat(((11, 21), (31, 41), (51, 61)))
    val m02            =  mat((11, 21), (31, 41), (51, 61))
    assert(m01.strictEquals(m02))
  }
```

There is still a need to verify good test coverage.  Also, there are some unused code in `Mat.scala` that can be cleaned up, but I'll have to get to it later.   I need to push this code so people can start looking at it.

Feedback is welcome.