### PR TITLE
add concatenateRows, concatenateColumns with tests

### DIFF
--- a/slash/shared/src/main/scala/slash/matrix/Mat.scala
+++ b/slash/shared/src/main/scala/slash/matrix/Mat.scala
@@ -329,6 +329,55 @@ object Mat {
     Util.fromString(content)
   }
 
+  /** Vertical tiling of one or more matrices (having same number of columns)
+   */
+  inline def concatenateRows[M <: Int, N <: Int, P <: Int, Q <: Int](m1: Mat[M,N], m2: Mat[P,Q])
+    (using ValueOf[M], ValueOf[N], ValueOf[P], ValueOf[Q], ValueOf[Sum[M,P]], N =:= Q): Mat[Sum[M,P], N] = {
+    val numCols = valueOf[N]
+    val res = Mat.zeros[Sum[M,P], N]
+    var j = 0
+    while(j < numCols) {
+      var i = 0
+      while(i < m1.rows) {
+        res(i,j) = m1(i,j)
+        i += 1
+      }
+      i = 0
+      while(i < m2.rows) {
+        res(i+m1.rows,j) = m2(i,j)
+        i += 1
+      }
+      j += 1
+    }
+    res
+  }
+
+  /** Horizontal tiling of one or more matrices (having same number of rows) */
+  inline def concatenateColumns[M <: Int, N <: Int, P <: Int, Q <: Int](m1: Mat[M,N], m2: Mat[P,Q])
+    (using ValueOf[M], ValueOf[N], ValueOf[P], ValueOf[Q], ValueOf[Sum[N,Q]], M =:= P): Mat[M, Sum[N,Q]] = {
+    val numRows = valueOf[M]
+    val res = Mat.zeros[M, Sum[N,Q]]
+    var i = 0
+    while(i < numRows){
+      var j = 0;
+      while(j < m1.columns) {
+        res(i,j) = m1(i,j)
+        j += 1
+      }
+      j = 0
+      while(j < m2.columns) {
+        res(i,j+m1.columns) = m2(i,j)
+        j += 1
+      }
+      i += 1
+    }
+    res
+  }
+
+  type Sum[N <: Int, Q <: Int] <: Int = N match
+    case 0 => Q
+    case S[n] => S[Sum[n, Q]]
+
   type Number = Int | Float | Long | Double
 
   type IsSingleton[T] <: Boolean = T match

--- a/tests/shared/src/test/scala/MatConcatenateTest.scala
+++ b/tests/shared/src/test/scala/MatConcatenateTest.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 dragonfly.ai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import slash.matrix.*
+
+class MatConcatenateTest extends munit.FunSuite {
+  test("can concatenate rows of 2 matrices") {
+    val mat1 = Mat[2,3](
+      0,1,2,
+      3,4,5
+    )
+    val mat2 = Mat[1,3](
+      6,7,8
+    )
+    val expected = Mat[3,3](
+      0,1,2,
+      3,4,5,
+      6,7,8
+    )
+    val allRows = Mat.concatenateRows(mat1,mat2)
+    assert(allRows.strictEquals(expected))
+  }
+  test("can concatenate columns of 2 matrices") {
+    val mat1 = Mat[2,3](
+      0,1,2,
+      3,4,5
+    )
+    val mat2 = Mat[2,2](
+      6,7,
+      8,9,
+    )
+    val expected = Mat[2,5](
+      0,1,2,6,7,
+      3,4,5,8,9
+    )
+    val allRows = Mat.concatenateColumns(mat1,mat2)
+    assert(allRows.strictEquals(expected))
+  }
+}

--- a/tests/shared/src/test/scala/MatConcatenateTest.scala
+++ b/tests/shared/src/test/scala/MatConcatenateTest.scala
@@ -49,4 +49,33 @@ class MatConcatenateTest extends munit.FunSuite {
     val allRows = Mat.concatenateColumns(mat1,mat2)
     assert(allRows.strictEquals(expected))
   }
+  test("can multiply concatenated matrices") {
+    val allRows: Mat[4,3] = {
+      val mat1 = Mat[2,3](
+        0,1,2,
+        3,4,5
+      )
+      val mat2 = Mat[2,3](
+        6,7,8,
+        10,11,12
+      )
+      Mat.concatenateRows(mat1,mat2)
+    }
+
+    val allCols: Mat[3,6] = {
+      val mat3 = Mat[3,3](
+        0,1,2,
+        3,4,5,
+        6,7,8,
+      )
+      val mat4 = Mat[3,3](
+        6,7,8,
+        10,11,12,
+        13,14,15
+      )
+      Mat.concatenateColumns(mat3,mat4)
+    }
+    val chek: Mat[4,6] = allRows * allCols
+    printf("%s\n", chek)
+  }
 }


### PR DESCRIPTION
Based on feedback, two new methods added, each taking 2 `Mat` parameters.
I named them `concatenateRows(m1,m2)` and `concatenateColumns(m1,m2)`, let me know if you prefer something different.

<table>
  <tr><th>Operation</th>
  <th>slash</th>
  <th>Breeze</th>
  <th>Matlab</th>
  <th>Numpy</th>
  <th>R</th></tr>
  <tr><td>Mat concatenate rows</td>
  <td>🟦concatenateRows(a,b)</td>
  <td>vertcat(a,b)</td>
  <td>[a ; b]</td>
  <td>vstack((a,b))</td>
  <td>rbind(a, b)</td></tr>
  <tr><td>Mat concatenate cols</td>
  <td>🟦concatenateColumns(d,e)</td>
  <td>horzcat(d,e)</td>
  <td>[d , e]</td>
  <td>hstack((d,e))</td>
  <td>cbind(d, e)</td></tr>
<table>

