### PR TITLE
Mat alternate reference and dereferencing implementation, with pos or neg row/column indexing

### DIFF
--- a/slash/shared/src/main/scala/slash/matrix/Mat.scala
+++ b/slash/shared/src/main/scala/slash/matrix/Mat.scala
@@ -984,11 +984,8 @@ class Mat[M <: Int, N <: Int](val values: NArray[Double])(using ValueOf[M], Valu
     val rowidx: Int = rowIndex(r)
     inline def :=(inline vector: Vec[N]): Unit = {
       val start: Int = rowidx * columns
-      var i = 0
-      while(i < columns) {
-        values(start+i) = vector(i)
-        i += 1
-      }
+      val src = vector.asInstanceOf[NArray[Double]]
+      narr.native.NArray.copyDoubleArray(src, 0, values, start, columns)
     }
     def show: String = rowVector(rowidx).show
     def asVec: Vec[N] = rowVector(rowidx)

--- a/tests/shared/src/test/scala/MatAssignDerefTest.scala
+++ b/tests/shared/src/test/scala/MatAssignDerefTest.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023 dragonfly.ai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import slash.matrix.*
+import slash.vector.Vec
+import scala.language.implicitConversions
+
+class MatAssignDerefTest extends munit.FunSuite {
+
+  test("rowVector extracts correct row"){
+    val expect = Vec(5, 6, 7, 8)
+    val m = Mat[3,4](
+       1,  2,  3,  4,
+       5,  6,  7,  8,
+       9, 10, 11, 12,
+    )
+    assert(m.rowVector(1).show == expect.show)
+  }
+  test("columnVector extracts correct column"){
+    val expect = Vec(3, 7, 11)
+    val m = Mat[3,4](
+       1,  2,  3,  4,
+       5,  6,  7,  8,
+       9, 10, 11, 12,
+    )
+    assert(m.columnVector(2).show == expect.show)
+  }
+  test("m(row,::) expression views the correct row"){
+    val expect = Vec(9, 10, 11, 12)
+    val m = Mat[3,4](
+       1,  2,  3,  4,
+       5,  6,  7,  8,
+       9, 10, 11, 12,
+    )
+    assert(m(2, ::).show == expect.show)
+  }
+  test("row overwrite m(x,::) modifies the correct row"){
+    val mat = Mat[3,4](
+       1,  2,  3,  4,
+       5,  6,  7,  8,
+       9, 10, 11, 12,
+    )
+    mat(0,::) := Vec[4](-1,-2,-3,-4)
+    val expect = Mat[3,4](
+      -1, -2, -3, -4,
+       5,  6,  7,  8,
+       9, 10, 11, 12,
+    )
+    assert(mat.strictEquals(expect))
+  }
+  test("m(::,col) expression views the correct column"){
+    val expect = Vec(2, 6, 10)
+    val m = Mat[3,4](
+       1,  2,  3,  4,
+       5,  6,  7,  8,
+       9, 10, 11, 12,
+    )
+    assert(m(::, 1).show == expect.show)
+  }
+  test("column overwrite m(::, x) modifies the correct column"){
+    val mat = Mat[3,4](
+       1,  2,  3,  4,
+       5,  6,  7,  8,
+       9, 10, 11, 12,
+    )
+    mat(::,1) := Vec[3](-1,-2,-3)
+    val expect = Mat[3,4](
+       1, -1,  3,  4,
+       5, -2,  7,  8,
+       9, -3, 11, 12,
+    )
+    assert(mat.strictEquals(expect))
+  }
+  test("last column is accessible via column index -1"){
+    val mat = Mat[3,4](
+       1,  2,  3,  4,
+       5,  6,  7,  8,
+       9, 10, 11, 12,
+    )
+    val lastcol: Vec[3] = mat(::, -1)
+    val expect = Vec[3](4, 8, 12)
+    assert(lastcol.show == expect.show)
+  }
+  test("middle row of Mat[3] is accessible via row index -2"){
+    val mat = Mat[3,4](
+       1,  2,  3,  4,
+       5,  6,  7,  8,
+       9, 10, 11, 12,
+    )
+    val midrow: Vec[4] = mat(-2, ::)
+    val expect = Vec[4](5, 6, 7, 8)
+    assert(midrow.show == expect.show)
+  }
+
+}

--- a/tests/shared/src/test/scala/MatAssignDerefTest.scala
+++ b/tests/shared/src/test/scala/MatAssignDerefTest.scala
@@ -104,5 +104,75 @@ class MatAssignDerefTest extends munit.FunSuite {
     val expect = Vec[4](5, 6, 7, 8)
     assert(midrow.show == expect.show)
   }
+  
+  // tests for illegal indexes
+  test("verify IllegalArgumentException for row index < -rows"){
+    val mat = Mat[3,4](
+       1,  2,  3,  4,
+       5,  6,  7,  8,
+       9, 10, 11, 12,
+    )
+    val badRowCheck: Boolean = try {
+      val illegalRow: Vec[4] = mat(-4, ::)
+      printf("illegalRow:\n%s\n", illegalRow)
+      false
+    } catch {
+    case _:IllegalArgumentException =>
+      true
+    }
+    printf("badRowCheck is %s\n", badRowCheck)
+    assert(badRowCheck, "failed to throw exception on negative row index")
+  }
+  test("verify IllegalArgumentException for row index >= rows"){
+    val mat = Mat[3,4](
+       1,  2,  3,  4,
+       5,  6,  7,  8,
+       9, 10, 11, 12,
+    )
+    val badRowCheck: Boolean = try {
+      val illegalRow: Vec[4] = mat(3, ::)
+      printf("illegalRow:\n%s\n", illegalRow)
+      false
+    } catch {
+    case _:IllegalArgumentException =>
+      true
+    }
+    printf("badRowCheck is %s\n", badRowCheck)
+    assert(badRowCheck, "failed to throw exception on above bound row index")
+  }
+  test("verify IllegalArgumentException for column index < -columns"){
+    val mat = Mat[3,4](
+       1,  2,  3,  4,
+       5,  6,  7,  8,
+       9, 10, 11, 12,
+    )
+    val badColumnCheck: Boolean = try {
+      val illegalCol: Vec[3] = mat(::, -5)
+      printf("illegalCol:\n%s\n", illegalCol)
+      false
+    } catch {
+    case _:IllegalArgumentException =>
+      true
+    }
+    printf("badColumnCheck is %s\n", badColumnCheck)
+    assert(badColumnCheck, "failed to throw exception on above bound column index")
+  }
+  test("verify IllegalArgumentException for column index >= columns"){
+    val mat = Mat[3,4](
+       1,  2,  3,  4,
+       5,  6,  7,  8,
+       9, 10, 11, 12,
+    )
+    val badColumnCheck: Boolean = try {
+      val illegalCol: Vec[3] = mat(::, 4)
+      printf("illegalCol:\n%s\n", illegalCol)
+      false
+    } catch {
+    case _:IllegalArgumentException =>
+      true
+    }
+    printf("badColumnCheck is %s\n", badColumnCheck)
+    assert(badColumnCheck, "failed to throw exception on above bound column index")
+  }
 
 }


### PR DESCRIPTION
Added breeze-like reference and dereference implementations.
Include negative indexing (relative to end-of-matrix).

This PR also fixes a bug where a negative column index would return the wrong data, and would only fail when of magnitude greater than `(m.columns * (m.rows - rowIndex))`.

Tests included.

<table>
  <tr><th>Matrix Operation</th>
  <th>slash</th>
  <th>Breeze</th>
  <th>Matlab</th>
  <th>Numpy</th>
  <th>R</th></tr>
  <tr><td>dereference column</td>
  <td>🟩a(::, 2)</td>
  <td>a(::, 2)</td>
  <td>a(:,2) = vec</td>
  <td>a[:,2] = vec</td>
  <td>a[,2] = vec</td></tr>
  <tr><td>dereference  row</td>
  <td>🟩a(3,::)</td>
  <td>a(3,::)</td>
  <td>a(3,:)</td>
  <td>a[3,:]</td>
  <td>a[3,]</td></tr>
  <tr><td>Assignment to column</td>
  <td>🟩a(::, 2) := vec</td>
  <td>a(::, 2) := vec</td>
  <td>a(:,2) = vec</td>
  <td>a[:,2] = vec</td>
  <td>a[,2] = vec</td></tr>
  <tr><td>Assignment to row</td>
  <td>🟩a(3,::) := vec</td>
  <td>a(3,::) := vec</td>
  <td>a(3,:) = vec</td>
  <td>a[3,:] = vec</td>
  <td>a[3,] = vec</td></tr>
  <tr><td>negative indexing</td>
  <td>🟩a(-1,::) := vec</td>
  <td>a(-1,::) := vec</td>
  <td>a(-1,:) = vec</td>
  <td>a[-1,:] = vec</td>
  <td>a[1,] = vec</td></tr>
</table>