### PR TITLE
left associative scalar math support

### DIFF
--- a/slash/shared/src/main/scala/slash/matrix/Mat.scala
+++ b/slash/shared/src/main/scala/slash/matrix/Mat.scala
@@ -239,8 +239,7 @@ object Mat {
    *    non-numeric fields, if present converted to `Double.NaN`
    *
    * @throws IllegalArgumentException on non-numeric fields.
-   * @param t0     a Tuple with M numeric columns (minimum of one row expected)
-   * @param tuparg zero or more Tuples each with M numeric columns
+   * @param tuparg Tuple of Doubles or Tuple of Tuple of Double
    * @return an M x N matrix consisting of values.
    */
   transparent inline def apply[M <: Int, N <: Int](tuparg: Tuple)(using ValueOf[M], ValueOf[N]): Mat[M,N] = {
@@ -795,14 +794,67 @@ class Mat[M <: Int, N <: Int](val values: NArray[Double])(using ValueOf[M], Valu
     this
   }
 
-  /** Multiply a matrix by a scalar, C = s*A
+  /** A = A + d
+  *
+  * @param d a scalar
+  * @return A + d
+  */
+  def addScalar(d: Double)(using ValueOf[N]): Mat[M,N] = {
+    for(i <- 0 until rows){
+      for(j <- 0 until columns){
+        apply(i,j) += d
+      }
+    }
+    this
+  }
+
+  /** A = A + d
+  *
+  * @param d a scalar
+  * @return A + d
+  */
+  def addScalar(n: Int)(using ValueOf[N]): Mat[M,N] = {
+    val d = n.toDouble
+    for(i <- 0 until rows){
+      for(j <- 0 until columns){
+        apply(i,j) += d.toDouble
+      }
+    }
+    this
+  }
+
+  /** Multiply a matrix by a scalar, C = A * s
     *
     * @param s scalar
-    * @return s*A
+    * @return A * s
     */
   inline def * (s: Double): Mat[M, N] = copy.times(s)
+  inline def * (s: Int): Mat[M, N] = copy.times(s)
 
-  inline def += (s:Double):Mat[M, N] = times(s)
+  inline def *= (s:Double):Mat[M, N] = times(s)
+  inline def *= (s:Int):Mat[M, N] = times(s)
+
+  /** Add a scalar to a matrix, C = A + s
+    *
+    * @param s scalar
+    * @return A + s
+    */
+  inline def + (s: Double): Mat[M, N] = copy.addScalar(s)
+  inline def + (s: Int): Mat[M, N] = copy.addScalar(s)
+
+  inline def += (s:Double):Mat[M, N] = addScalar(s)
+  inline def += (s:Int):Mat[M, N] = addScalar(s)
+
+  /** Subtract a scalar from a matrix, C = A + s
+    *
+    * @param s scalar
+    * @return A + s
+    */
+  inline def - (s: Double): Mat[M, N] = copy.addScalar(-s)
+  inline def - (s: Int): Mat[M, N] = copy.addScalar(-s)
+
+  inline def -= (s:Double):Mat[M, N] = addScalar(-s)
+  inline def -= (s:Int):Mat[M, N] = addScalar(-s)
 
   /** Multiply a matrix by a scalar in place, A = s*A
     *
@@ -812,6 +864,15 @@ class Mat[M <: Int, N <: Int](val values: NArray[Double])(using ValueOf[M], Valu
   def times(s: Double): Mat[M, N] = {
     var i:Int = 0; while (i < values.length) {
       values(i) = values(i) * s
+      i += 1
+    }
+    this
+  }
+
+  def times(s: Int): Mat[M, N] = {
+    val d = s.toDouble
+    var i:Int = 0; while (i < values.length) {
+      values(i) = values(i) * d
       i += 1
     }
     this

--- a/slash/shared/src/main/scala/slash/matrix/Mat.scala
+++ b/slash/shared/src/main/scala/slash/matrix/Mat.scala
@@ -826,12 +826,9 @@ class Mat[M <: Int, N <: Int](val values: NArray[Double])(using ValueOf[M], Valu
 
   inline def += (s:Double):Mat[M, N] = addScalar(s)
 
-  /** Subtract a scalar from a matrix, C = A + s
-    *
-    * @param s scalar
-    * @return A + s
-    */
   inline def - (s: Double): Mat[M, N] = copy.addScalar(-s)
+
+  inline def -= (s: Double): Mat[M, N] = addScalar(-s)
 
   /** Multiply a matrix by a scalar in place, A = s*A
     *

--- a/slash/shared/src/main/scala/slash/matrix/Mat.scala
+++ b/slash/shared/src/main/scala/slash/matrix/Mat.scala
@@ -800,10 +800,10 @@ class Mat[M <: Int, N <: Int](val values: NArray[Double])(using ValueOf[M], Valu
   * @return A + d
   */
   def addScalar(d: Double)(using ValueOf[N]): Mat[M,N] = {
-    for(i <- 0 until rows){
-      for(j <- 0 until columns){
-        apply(i,j) += d
-      }
+    var i:Int = 0
+    while(i < values.length){
+      values(i) += d
+      i += 1
     }
     this
   }
@@ -813,15 +813,7 @@ class Mat[M <: Int, N <: Int](val values: NArray[Double])(using ValueOf[M], Valu
   * @param d a scalar
   * @return A + d
   */
-  def addScalar(n: Int)(using ValueOf[N]): Mat[M,N] = {
-    val d = n.toDouble
-    for(i <- 0 until rows){
-      for(j <- 0 until columns){
-        apply(i,j) += d.toDouble
-      }
-    }
-    this
-  }
+  def addScalar(n: Int)(using ValueOf[N]): Mat[M,N] = addScalar(n.toDouble)
 
   /** Multiply a matrix by a scalar, C = A * s
     *
@@ -851,10 +843,6 @@ class Mat[M <: Int, N <: Int](val values: NArray[Double])(using ValueOf[M], Valu
     * @return A + s
     */
   inline def - (s: Double): Mat[M, N] = copy.addScalar(-s)
-  inline def - (s: Int): Mat[M, N] = copy.addScalar(-s)
-
-  inline def -= (s:Double):Mat[M, N] = addScalar(-s)
-  inline def -= (s:Int):Mat[M, N] = addScalar(-s)
 
   /** Multiply a matrix by a scalar in place, A = s*A
     *

--- a/slash/shared/src/main/scala/slash/matrix/Mat.scala
+++ b/slash/shared/src/main/scala/slash/matrix/Mat.scala
@@ -808,23 +808,14 @@ class Mat[M <: Int, N <: Int](val values: NArray[Double])(using ValueOf[M], Valu
     this
   }
 
-  /** A = A + d
-  *
-  * @param d a scalar
-  * @return A + d
-  */
-  def addScalar(n: Int)(using ValueOf[N]): Mat[M,N] = addScalar(n.toDouble)
-
   /** Multiply a matrix by a scalar, C = A * s
     *
     * @param s scalar
     * @return A * s
     */
   inline def * (s: Double): Mat[M, N] = copy.times(s)
-  inline def * (s: Int): Mat[M, N] = copy.times(s)
 
   inline def *= (s:Double):Mat[M, N] = times(s)
-  inline def *= (s:Int):Mat[M, N] = times(s)
 
   /** Add a scalar to a matrix, C = A + s
     *
@@ -832,10 +823,8 @@ class Mat[M <: Int, N <: Int](val values: NArray[Double])(using ValueOf[M], Valu
     * @return A + s
     */
   inline def + (s: Double): Mat[M, N] = copy.addScalar(s)
-  inline def + (s: Int): Mat[M, N] = copy.addScalar(s)
 
   inline def += (s:Double):Mat[M, N] = addScalar(s)
-  inline def += (s:Int):Mat[M, N] = addScalar(s)
 
   /** Subtract a scalar from a matrix, C = A + s
     *
@@ -852,15 +841,6 @@ class Mat[M <: Int, N <: Int](val values: NArray[Double])(using ValueOf[M], Valu
   def times(s: Double): Mat[M, N] = {
     var i:Int = 0; while (i < values.length) {
       values(i) = values(i) * s
-      i += 1
-    }
-    this
-  }
-
-  def times(s: Int): Mat[M, N] = {
-    val d = s.toDouble
-    var i:Int = 0; while (i < values.length) {
-      values(i) = values(i) * d
       i += 1
     }
     this

--- a/slash/shared/src/main/scala/slash/matrix/package.scala
+++ b/slash/shared/src/main/scala/slash/matrix/package.scala
@@ -35,6 +35,31 @@ package object matrix {
   }
 
   /**
+   * Support left add / multiply by Doubles.
+   */
+  extension(s: Double) {
+    inline def +[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.copy.addScalar(s)
+    inline def +=[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.addScalar(s)
+    inline def -[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.copy.addScalar(-s)
+    inline def -=[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.addScalar(-s)
+    inline def *[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.copy.times(s)
+    inline def *=[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.times(s)
+  }
+
+  /**
+   * Support left add / multiply by Ints.
+   */
+  extension(s: Int) {
+    inline def +[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.copy.addScalar(s.toDouble)
+    inline def +=[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.addScalar(s.toDouble)
+    inline def -[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.copy.addScalar(-s.toDouble)
+    inline def -=[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.addScalar(-s.toDouble)
+    inline def *[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.copy.times(s.toDouble)
+    inline def *=[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.times(s.toDouble)
+  }
+
+
+  /**
    * Extension Methods for Square Matrices.
    */
   extension [MN <: Int](m: Mat[MN, MN])(using ValueOf[MN]) {

--- a/slash/shared/src/main/scala/slash/matrix/package.scala
+++ b/slash/shared/src/main/scala/slash/matrix/package.scala
@@ -39,25 +39,8 @@ package object matrix {
    */
   extension(s: Double) {
     inline def +[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.copy.addScalar(s)
-    inline def +=[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.addScalar(s)
-    inline def -[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.copy.addScalar(-s)
-    inline def -=[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.addScalar(-s)
     inline def *[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.copy.times(s)
-    inline def *=[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.times(s)
   }
-
-  /**
-   * Support left add / multiply by Ints.
-   */
-  extension(s: Int) {
-    inline def +[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.copy.addScalar(s.toDouble)
-    inline def +=[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.addScalar(s.toDouble)
-    inline def -[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.copy.addScalar(-s.toDouble)
-    inline def -=[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.addScalar(-s.toDouble)
-    inline def *[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.copy.times(s.toDouble)
-    inline def *=[M <: Int, N <: Int](inline m: Mat[M,N])(using ValueOf[M], ValueOf[N]): Mat[M,N] = m.times(s.toDouble)
-  }
-
 
   /**
    * Extension Methods for Square Matrices.

--- a/tests/shared/src/test/scala/MatScalarMathTest.scala
+++ b/tests/shared/src/test/scala/MatScalarMathTest.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 dragonfly.ai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import slash.matrix.*
+import scala.language.implicitConversions
+
+class MatScalarMathTest extends munit.FunSuite {
+
+  test("verify Mat scalar add is commutative") {
+    val a0 = Mat[2,6](2,  3,  4,  5,  6,  7, 8,  9, 10, 11, 12, 13)
+    val a1 = a0 + 2
+    val a2 = 2.0 + a0
+    val a3 = a0 + 2.0
+    val a4 = 2 + a0
+    assert(a1.strictEquals(a2) && a1.strictEquals(a3) && a1.strictEquals(a4))
+  }
+
+  test("verify Mat scalar subtract is commutative") {
+    val a0 = Mat[2,6](2,  3,  4,  5,  6,  7, 8,  9, 10, 11, 12, 13)
+    val a1 = a0 - 2
+    val a2 = -2.0 + a0
+    val a3 = a0 - 2.0
+    val a4 = -2 + a0
+    assert(a1.strictEquals(a2) && a1.strictEquals(a3) && a1.strictEquals(a4))
+  }
+
+  test("verify Mat scalar multiply is commutative") {
+    val m0 = Mat[2,6](2,  3,  4,  5,  6,  7, 8,  9, 10, 11, 12, 13)
+    val m1 = m0 * 3
+    val m2 = 3.0 * m0
+    val m3 = m0 * 3.0
+    val m4 = 3 * m0
+    assert(m1.strictEquals(m2) && m1.strictEquals(m3) && m1.strictEquals(m4))
+  }
+
+}

--- a/tests/shared/src/test/scala/MatScalarMathTest.scala
+++ b/tests/shared/src/test/scala/MatScalarMathTest.scala
@@ -46,4 +46,20 @@ class MatScalarMathTest extends munit.FunSuite {
     assert(m1.strictEquals(m2) && m1.strictEquals(m3) && m1.strictEquals(m4))
   }
 
+  test("verify Mat - scalar") {
+    val matrix = Mat[2,6]( 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)
+    val expect = Mat[2,6](-1, 0, 1, 2, 3, 4, 5, 6,  7,  8,  9, 10)
+    val matmod = matrix - 3
+    printf("%s\n", matmod)
+    assert(matmod.strictEquals(expect))
+  }
+
+  test("verify Mat -= scalar") {
+    val matrix = Mat[2,6]( 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)
+    val expect = Mat[2,6](-1, 0, 1, 2, 3, 4, 5, 6,  7,  8,  9, 10)
+    matrix -= 3
+    printf("%s\n", matrix)
+    assert(matrix.strictEquals(expect))
+  }
+
 }


### PR DESCRIPTION
Left add / subtract / multiply of matrices.
Already had implemented right add / subtract multiply as methods on `Mat` class.
This adds extensions to types `Double` and `Int` to that the following two expressions have the same semantics:
```scala
val m = Mat[1,2](1,2)
val mat1 = 2 * m
val mat2 = m * 2
```

tests included