### PR TITLE
Matrix reshape and flatten with tests

### DIFF
--- a/slash/shared/src/main/scala/slash/matrix/package.scala
+++ b/slash/shared/src/main/scala/slash/matrix/package.scala
@@ -35,6 +35,29 @@ package object matrix {
   }
 
   /**
+   * Extension methods for all matrices.
+   */
+  extension[M <: Int, N <: Int](a: Mat[M, N])(using ValueOf[M], ValueOf[N]) {
+
+    /** cast matrix as Mat[R,C]
+    *
+    * @param R new vertical dimension
+    * @param C new horizontal dimension
+    * @return same values, but recast to RxC
+    */
+    def reshape[R <: Int, C <: Int](using ValueOf[R], ValueOf[C]): Mat[R,C] = {
+      val (msize,nsize) = (valueOf[M], valueOf[N])
+      val (r,c) = (valueOf[R], valueOf[C])
+      require(msize*nsize == r*c, s"$msize x $nsize != $r x $c")
+      new Mat[R,C](a.values)
+    }
+
+    /** values as a Vector.
+     */
+    def flatten: Vec[M*N] = a.values.asInstanceOf[Vec[M*N]]
+  }
+
+  /**
    * Extension Methods for Square Matrices.
    */
   extension [MN <: Int](m: Mat[MN, MN])(using ValueOf[MN]) {

--- a/slash/shared/src/main/scala/slash/matrix/package.scala
+++ b/slash/shared/src/main/scala/slash/matrix/package.scala
@@ -45,12 +45,7 @@ package object matrix {
     * @param C new horizontal dimension
     * @return same values, but recast to RxC
     */
-    def reshape[R <: Int, C <: Int](using ValueOf[R], ValueOf[C]): Mat[R,C] = {
-      val (msize,nsize) = (valueOf[M], valueOf[N])
-      val (r,c) = (valueOf[R], valueOf[C])
-      require(msize*nsize == r*c, s"$msize x $nsize != $r x $c")
-      new Mat[R,C](a.values)
-    }
+    def reshape[R <: Int, C <: Int](using ValueOf[R], ValueOf[C]): Mat[R,C] = new Mat[R,C](a.values)
 
     /** values as a Vector.
      */

--- a/tests/shared/src/test/scala/MatReshapeFlattenTest.scala
+++ b/tests/shared/src/test/scala/MatReshapeFlattenTest.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 dragonfly.ai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import slash.vector.*
+import slash.matrix.*
+
+class MatReshapeFlattenTest extends munit.FunSuite {
+
+  test("verify Mat.reshape") {
+    val mat1 = Mat.random[10,7](-1.0, 2.0)
+    val mat2 = mat1.reshape[5,14]
+    val mat3: Mat[5,14] = mat2 // dimensions verified by compiler
+    assert(mat1.values == mat2.values && mat2.strictEquals(mat3))
+  }
+  test("verify flatten") {
+    val mat = Mat.random[10,7](-1.0, 2.0)
+    val vec: Vec[70] = mat.flatten
+    assert(mat.values == vec)
+  }
+}


### PR DESCRIPTION
Added extension methods for matrix reshape and flatten, plus tests.

<table>
  <tr><th>Operation</th>
  <th>slash</th>
  <th>Breeze</th>
  <th>Matlab</th>
  <th>Numpy</th>
  <th>R</th></tr>
  <tr><td>Reshaping</td>
  <td>🟦a.reshape[3,2]</td>
  <td>a.reshape(3, 2)</td>
  <td>reshape(a, 3, 2)</td>
  <td>a.reshape(3,2)</td>
  <td>matrix(a,nrow=3,byrow=T)</td></tr>
  <tr><td>Flatten</td>
  <td>🟦a.flatten</td>
  <td>a.toDenseVector</td>
  <td>a(:)</td>
  <td>a.flatten()</td>
  <td>as.vector(a)</td></tr>
</table>